### PR TITLE
Fix uri scheme validation

### DIFF
--- a/src/formats.ts
+++ b/src/formats.ts
@@ -79,8 +79,8 @@ export const formats: {fast: DefinedFormats; full: DefinedFormats} = {
     time: /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)?$/i,
     "date-time": /^\d\d\d\d-[0-1]\d-[0-3]\d[t\s](?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i,
     // uri: https://github.com/mafintosh/is-my-json-valid/blob/master/formats.js
-    uri: /^(?:[a-z][a-z0-9+-.]*:)(?:\/?\/)?[^\s]*$/i,
-    "uri-reference": /^(?:(?:[a-z][a-z0-9+-.]*:)?\/?\/)?(?:[^\\\s#][^\s#]*)?(?:#[^\\\s]*)?$/i,
+    uri: /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/i,
+    "uri-reference": /^(?:(?:[a-z][a-z0-9+\-.]*:)?\/?\/)?(?:[^\\\s#][^\s#]*)?(?:#[^\\\s]*)?$/i,
     "uri-template": URITEMPLATE,
     url: URL,
     // email (sources from jsen validator):


### PR DESCRIPTION
`foo,bar:baz` is not a valid uri.

Refs: https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/419