### PR TITLE
Make ajv a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/ajv-validator/ajv-formats/issues"
   },
   "homepage": "https://github.com/ajv-validator/ajv-formats#readme",
-  "dependencies": {
+  "peerDependencies": {
     "ajv": "^7.0.0"
   },
   "devDependencies": {
@@ -43,6 +43,7 @@
     "@types/node": "^14.10.1",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
+    "ajv": "^7.0.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
     "husky": "^4.2.5",


### PR DESCRIPTION
Making `ajv` a peer dependency of `ajv-formats` resolves issue #13 that is causing TypeScript version mismatch errors on every ajv upgrade.