### PR TITLE
Added openApi spec formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The package defines these formats:
 - _uuid_: Universally Unique IDentifier according to [RFC4122](http://tools.ietf.org/html/rfc4122).
 - _json-pointer_: JSON-pointer according to [RFC6901](https://tools.ietf.org/html/rfc6901).
 - _relative-json-pointer_: relative JSON-pointer according to [this draft](http://tools.ietf.org/html/draft-luff-relative-json-pointer-00).
+- _byte_: base64 encoded data according to the [openApi 3.0.0 specification](https://spec.openapis.org/oas/v3.0.0#data-types)
+- _int32_: signed 32 bits integer according to the [openApi 3.0.0 specification](https://spec.openapis.org/oas/v3.0.0#data-types)
+- _int64_: signed 64 bits according to the [openApi 3.0.0 specification](https://spec.openapis.org/oas/v3.0.0#data-types)
+- _float_: float according to the [openApi 3.0.0 specification](https://spec.openapis.org/oas/v3.0.0#data-types)
+- _double_: double according to the [openApi 3.0.0 specification](https://spec.openapis.org/oas/v3.0.0#data-types)
+- _password_: password string according to the [openApi 3.0.0 specification](https://spec.openapis.org/oas/v3.0.0#data-types)
+- _binary_: binary string according to the [openApi 3.0.0 specification](https://spec.openapis.org/oas/v3.0.0#data-types)
 
 See regular expressions used for format validation and the sources that were used in [formats.ts](https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts).
 

--- a/src/formats.ts
+++ b/src/formats.ts
@@ -73,13 +73,13 @@ export const fullFormats: DefinedFormats = {
   // byte: https://github.com/miguelmota/is-base64
   byte: /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/gm,
   // signed 32 bit integer
-  int32: validateInteger(32),
+  int32: {type: "number", validate: validateInt32},
   // signed 64 bit integer
-  int64: validateInteger(64),
+  int64: {type: "number", validate: validateInt64},
   // C-type float
-  float: validateNumber(128),
+  float: {type: "number", validate: validateNumber},
   // C-type double
-  double: validateNumber(1024),
+  double: {type: "number", validate: validateNumber},
   // hint to the UI to hide input strings
   password: true,
   // unchecked string payload
@@ -191,17 +191,20 @@ function uri(str: string): boolean {
   return NOT_URI_FRAGMENT.test(str) && URI.test(str)
 }
 
-function validateInteger(bits: number): (value: number | string) => boolean {
-  const max = BigInt(2) ** BigInt(bits - 1)
-  const min = max * BigInt(-1)
-  return (value) => Number.isInteger(+value) && BigInt(value) <= max && BigInt(value) >= min
+const MIN_INT32 = -(2 ** 31)
+const MAX_INT32 = 2 ** 31 - 1
+
+function validateInt32(value: number): boolean {
+  return Number.isInteger(value) && value <= MAX_INT32 && value >= MIN_INT32
 }
 
-function validateNumber(bits: number): (value: number | string) => boolean {
-  const max = Number(BigInt(2) ** BigInt(bits - 1))
-  const min = max * -1
+function validateInt64(value: number): boolean {
+  // JSON and javascript max Int is 2**53, so any int that passes isInteger is valid for Int64
+  return Number.isInteger(value)
+}
 
-  return (value) => max >= value && min <= value
+function validateNumber(): boolean {
+  return true
 }
 
 const Z_ANCHOR = /[^\\]\\Z/

--- a/tests/extras/format.json
+++ b/tests/extras/format.json
@@ -756,22 +756,32 @@
     "tests": [
       {
         "description": "256 is ok",
-        "data": "256",
+        "data": 256,
         "valid": true
       },
       {
         "description": "256.1 fails",
-        "data": "256.1",
+        "data": 256.1,
         "valid": false
       },
       {
-        "description": "2**32 fails",
-        "data": "4294967296",
+        "description": "-(2**31) is ok",
+        "data": -2147483648,
+        "valid": true
+      },
+      {
+        "description": "-(2**31) - 1 fails",
+        "data": -2147483649,
         "valid": false
       },
       {
-        "description": "non-numeric fails",
-        "data": "x",
+        "description": "(2**31)-1 is ok",
+        "data": 2147483647,
+        "valid": true
+      },
+      {
+        "description": "2**31 fails",
+        "data": 2147483648,
         "valid": false
       }
     ]
@@ -782,22 +792,12 @@
     "tests": [
       {
         "description": "256 is ok",
-        "data": "256",
+        "data": 256,
         "valid": true
       },
       {
-        "description": "256.1 fails",
-        "data": "256.1",
-        "valid": false
-      },
-      {
-        "description": "2**64 fails",
-        "data": "18446744073709551616",
-        "valid": false
-      },
-      {
-        "description": "non-numeric fails",
-        "data": "x",
+        "description": "float fails",
+        "data": 256.1,
         "valid": false
       }
     ]
@@ -807,24 +807,9 @@
     "schema": {"format": "float"},
     "tests": [
       {
-        "description": "256 is ok",
-        "data": "256",
-        "valid": true
-      },
-      {
         "description": "256.1 is ok",
-        "data": "256.1",
+        "data": 256.1,
         "valid": true
-      },
-      {
-        "description": "2**128 fails",
-        "data": "3.402823669209385e+38",
-        "valid": false
-      },
-      {
-        "description": "non-numeric fails",
-        "data": "x",
-        "valid": false
       }
     ]
   },
@@ -833,29 +818,9 @@
     "schema": {"format": "double"},
     "tests": [
       {
-        "description": "256 is ok",
-        "data": "256",
-        "valid": true
-      },
-      {
         "description": "256.1 is ok",
         "data": "256.1",
         "valid": true
-      },
-      {
-        "description": "2**1023 is ok",
-        "data": "8.98846567431158e+307",
-        "valid": true
-      },
-      {
-        "description": "2**1024 fails",
-        "data": "179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216n",
-        "valid": false
-      },
-      {
-        "description": "non-numeric fails",
-        "data": "x",
-        "valid": false
       }
     ]
   },

--- a/tests/extras/format.json
+++ b/tests/extras/format.json
@@ -728,5 +728,157 @@
         "valid": true
       }
     ]
+  },
+  {
+    "description": "validation of Byte",
+    "schema": {"format": "byte"},
+    "tests": [
+      {
+        "description": "'hello world' encoded in base64",
+        "data": "aGVsbG8gd29ybGQ=",
+        "valid": true
+      },
+      {
+        "description": "multiline base64",
+        "data": "VGhpcyBpcyBhIGJhc2U2NCBtdWx0aWxpbmUgc3RyaW5nIHRoYXQgc3BhbnMgbW9yZSB0aGFuIDc2\nIGNoYXJhY3RlcnMgdG8gdGVzdCBtdWx0aWxpbmUgY2FwYWJpbGl0aWVzCg==",
+        "valid": true
+      },
+      {
+        "description": "Invalid base64",
+        "data": "aGVsbG8gd29ybG=",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of int32",
+    "schema": {"format": "int32"},
+    "tests": [
+      {
+        "description": "256 is ok",
+        "data": "256",
+        "valid": true
+      },
+      {
+        "description": "256.1 fails",
+        "data": "256.1",
+        "valid": false
+      },
+      {
+        "description": "2**32 fails",
+        "data": "4294967296",
+        "valid": false
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of int64",
+    "schema": {"format": "int64"},
+    "tests": [
+      {
+        "description": "256 is ok",
+        "data": "256",
+        "valid": true
+      },
+      {
+        "description": "256.1 fails",
+        "data": "256.1",
+        "valid": false
+      },
+      {
+        "description": "2**64 fails",
+        "data": "18446744073709551616",
+        "valid": false
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of float",
+    "schema": {"format": "float"},
+    "tests": [
+      {
+        "description": "256 is ok",
+        "data": "256",
+        "valid": true
+      },
+      {
+        "description": "256.1 is ok",
+        "data": "256.1",
+        "valid": true
+      },
+      {
+        "description": "2**128 fails",
+        "data": "3.402823669209385e+38",
+        "valid": false
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of double",
+    "schema": {"format": "double"},
+    "tests": [
+      {
+        "description": "256 is ok",
+        "data": "256",
+        "valid": true
+      },
+      {
+        "description": "256.1 is ok",
+        "data": "256.1",
+        "valid": true
+      },
+      {
+        "description": "2**1023 is ok",
+        "data": "8.98846567431158e+307",
+        "valid": true
+      },
+      {
+        "description": "2**1024 fails",
+        "data": "179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216n",
+        "valid": false
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of password",
+    "schema": {"format": "password"},
+    "tests": [
+      {
+        "description": "'password string' is ok",
+        "data": "password string",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "validation of binary",
+    "schema": {"format": "binary"},
+    "tests": [
+      {
+        "description": "'binary string' is ok",
+        "data": "binary string",
+        "valid": true
+      }
+    ]
   }
 ]

--- a/tests/extras/format.json
+++ b/tests/extras/format.json
@@ -752,7 +752,7 @@
   },
   {
     "description": "validation of int32",
-    "schema": {"format": "int32"},
+    "schema": {"type": "number", "format": "int32"},
     "tests": [
       {
         "description": "256 is ok",
@@ -783,12 +783,17 @@
         "description": "2**31 fails",
         "data": 2147483648,
         "valid": false
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
       }
     ]
   },
   {
     "description": "validation of int64",
-    "schema": {"format": "int64"},
+    "schema": {"type": "number", "format": "int64"},
     "tests": [
       {
         "description": "256 is ok",
@@ -799,28 +804,43 @@
         "description": "float fails",
         "data": 256.1,
         "valid": false
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
       }
     ]
   },
   {
     "description": "validation of float",
-    "schema": {"format": "float"},
+    "schema": {"type": "number", "format": "float"},
     "tests": [
       {
         "description": "256.1 is ok",
         "data": 256.1,
         "valid": true
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
       }
     ]
   },
   {
     "description": "validation of double",
-    "schema": {"format": "double"},
+    "schema": {"type": "number", "format": "double"},
     "tests": [
       {
         "description": "256.1 is ok",
-        "data": "256.1",
+        "data": 256.1,
         "valid": true
+      },
+      {
+        "description": "non-numeric fails",
+        "data": "x",
+        "valid": false
       }
     ]
   },


### PR DESCRIPTION
As discussed in #9 I added formats for:
- byte
- int32
- int64
- float
- double
- password
- binary
As defined in the OpenAPI specification at https://spec.openapis.org/oas/v3.0.0#data-types

Kind regards,
Hans

