### PR TITLE
Fixed spelling in tests

### DIFF
--- a/tests/extras/formatMinimum.json
+++ b/tests/extras/formatMinimum.json
@@ -179,7 +179,7 @@
         "valid": false
       },
       {
-        "description": "same date, time before the minimum time is stillinvalid",
+        "description": "same date, time before the minimum time is still invalid",
         "data": "2015-08-17T10:33:55.000Z",
         "valid": false
       },

--- a/tests/extras/issues/1061_alternative_time_offsets.json
+++ b/tests/extras/issues/1061_alternative_time_offsets.json
@@ -4,7 +4,7 @@
     "schema": {"format": "date-time"},
     "tests": [
       {
-        "description": "valid positiive two digit",
+        "description": "valid positive two digit",
         "data": "2016-01-31T02:31:17+01",
         "valid": true
       },
@@ -14,7 +14,7 @@
         "valid": true
       },
       {
-        "description": "valid positiive four digit no colon",
+        "description": "valid positive four digit no colon",
         "data": "2016-01-31T02:31:17+0130",
         "valid": true
       },
@@ -24,7 +24,7 @@
         "valid": true
       },
       {
-        "description": "invalid positiive three digit no colon",
+        "description": "invalid positive three digit no colon",
         "data": "2016-01-31T02:31:17+013",
         "valid": false
       },
@@ -40,7 +40,7 @@
     "schema": {"format": "time"},
     "tests": [
       {
-        "description": "valid positiive two digit",
+        "description": "valid positive two digit",
         "data": "02:31:17+01",
         "valid": true
       },
@@ -50,7 +50,7 @@
         "valid": true
       },
       {
-        "description": "valid positiive four digit no colon",
+        "description": "valid positive four digit no colon",
         "data": "02:31:17+0130",
         "valid": true
       },
@@ -60,7 +60,7 @@
         "valid": true
       },
       {
-        "description": "invalid positiive three digit no colon",
+        "description": "invalid positive three digit no colon",
         "data": "02:31:17+013",
         "valid": false
       },


### PR DESCRIPTION
#8 also contained a few fixes for spelling errors in the tests.
No functional changes, just text in test descriptions.
Since #8 got cancelled I thought I'd fix them as well.

Kind regards,
Hans