### PR TITLE
account for ajv.opts.code.esm option in addFormats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,12 @@ formatsPlugin.get = (name: FormatName, mode: FormatMode = "full"): Format => {
 }
 
 function addFormats(ajv: Ajv, list: FormatName[], fs: DefinedFormats, exportName: Name): void {
-  ajv.opts.code.formats ??= _`require("ajv-formats/dist/formats").${exportName}`
+  if (ajv.opts.code.esm) {
+    ajv.opts.code.formats ??= _`(await import("ajv-formats/dist/formats.js"))['${exportName}']`
+  } else {
+    ajv.opts.code.formats ??= _`require("ajv-formats/dist/formats").${exportName}`
+  }
+
   for (const f of list) ajv.addFormat(f, fs[f])
 }
 


### PR DESCRIPTION
Closes #68

This checks `ajv.opts.code.esm` and uses a dynamic `import` if true, otherwise it uses previous behavior.

I'm not sure how best to add a test for this so would be happy to add that based on any suggestions you have.