### PR TITLE
fix: Provide named export alongside default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ JSON Schema formats for Ajv
 
 ```javascript
 // ESM/TypeScript import
-import Ajv from "ajv"
-import addFormats from "ajv-formats"
+import {Ajv} from "ajv"
+import {addFormats} from "ajv-formats"
 // Node.js require:
-const Ajv = require("ajv")
-const addFormats = require("ajv-formats")
+const {Ajv} = require("ajv")
+const {addFormats} = require("ajv-formats")
 
 const ajv = new Ajv()
 addFormats(ajv)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,13 +33,13 @@ const formatsPlugin: FormatsPlugin = (
   opts: FormatsPluginOptions = {keywords: true}
 ): Ajv => {
   if (Array.isArray(opts)) {
-    addFormats(ajv, opts, fullFormats, fullName)
+    _addFormats(ajv, opts, fullFormats, fullName)
     return ajv
   }
   const [formats, exportName] =
     opts.mode === "fast" ? [fastFormats, fastName] : [fullFormats, fullName]
   const list = opts.formats || formatNames
-  addFormats(ajv, list, formats, exportName)
+  _addFormats(ajv, list, formats, exportName)
   if (opts.keywords) formatLimit(ajv)
   return ajv
 }
@@ -51,7 +51,7 @@ formatsPlugin.get = (name: FormatName, mode: FormatMode = "full"): Format => {
   return f
 }
 
-function addFormats(ajv: Ajv, list: FormatName[], fs: DefinedFormats, exportName: Name): void {
+function _addFormats(ajv: Ajv, list: FormatName[], fs: DefinedFormats, exportName: Name): void {
   ajv.opts.code.formats ??= _`require("ajv-formats/dist/formats").${exportName}`
   for (const f of list) ajv.addFormat(f, fs[f])
 }
@@ -60,3 +60,4 @@ module.exports = exports = formatsPlugin
 Object.defineProperty(exports, "__esModule", {value: true})
 
 export default formatsPlugin
+export const addFormats = formatsPlugin


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes https://github.com/ajv-validator/ajv/issues/2132
Related to https://github.com/ajv-validator/ajv/pull/2352.

**What changes did you make?**

https://github.com/ajv-validator/ajv-formats/commit/17382ff147100e2aba4eb489291274c9ede80026: Created additional named export `addFormats` to the default export.
https://github.com/ajv-validator/ajv-formats/commit/f33003261657f20d1e202bf06e421c3e3591ec2c: Updated the documentation to use the named exports consistently.

**Is there anything that requires more attention while reviewing?**

The default export is the `FormatsPlugin` instance, but in all examples it is referred to as `addFormats`. This is a bit confusing, as there is another `addFormats` function that is used only internally and is not exported. I renamed it to `_addFormats` to avoid a naming conflict.

The existing default exports are untouched, so backwards compatibility is guaranteed.

