### PR TITLE
add boolean format to fullFormats

### DIFF
--- a/src/formats.ts
+++ b/src/formats.ts
@@ -43,6 +43,7 @@ function fmtDef(
 }
 
 export const fullFormats: DefinedFormats = {
+  boolean: /^(true|false|0|1|yes|no|enabled|disabled|on|off)$/i,
   // date: http://tools.ietf.org/html/rfc3339#section-5.6
   date: fmtDef(date, compareDate),
   // date-time: http://tools.ietf.org/html/rfc3339#section-5.6


### PR DESCRIPTION
This fixes errors like `Failed to validate: unknown format "boolean" ignored in schema at path "#/properties/App_RapidStartup"` produced by https://app.quicktype.io/schema